### PR TITLE
Use explicit call_types when calling read_tsv

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# rhmmer (development version)
+
+* tests now pass with readr 2.0.0
+
 # rhmmer v0.1.0
 
  * Initial release

--- a/R/parse.R
+++ b/R/parse.R
@@ -84,7 +84,7 @@ read_domtblout <- function(file){
       perl = TRUE
     ) %>%
     paste0(collapse="\n") %>%
-    readr::read_tsv(col_names=c('X', 'description'), comment='#', na='-') %>%
+    readr::read_tsv(col_names=c('X', 'description'), comment='#', na='-', col_types = "cc") %>%
     tidyr::separate(.data$X, head(names(col_types$cols), -1), sep=' +') %>%
     readr::type_convert(col_types=col_types)
 }

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -19,7 +19,7 @@ test_that("read_domtblout works", {
 })
 
 test_that("using the wrong reader fails", {
-  expect_warning(read_domtblout(tblout_file))
+  expect_error(read_domtblout(tblout_file))
   expect_warning(read_tblout(domtblout_file))
 })
 


### PR DESCRIPTION
This suppresses the col_spec output and is generally better practice to
always specify the column types rather than relying on guessing if you
know the expected types.

In readr 2.0.0 the column types will be shown as a message, which causes
the tests against `expect_silent()` to fail.

In addition what used to be a warning is now an error when you pass the
wrong input type, so that change was made as well.